### PR TITLE
Na NFCe não é obrigatório o destinatário

### DIFF
--- a/src/Traits/TraitEPECNfce.php
+++ b/src/Traits/TraitEPECNfce.php
@@ -92,7 +92,7 @@ trait TraitEPECNfce
         $tpNF = $dom->getElementsByTagName('tpNF')->item(0)->nodeValue;
         $emitIE = $emit->getElementsByTagName('IE')->item(0)->nodeValue;
         $destUF = $uf;
-        if (!empty($dest)) {
+        if (!empty($dest) && isset($dest->getElementsByTagName('UF')->item(0)->nodeValue)) {
             $destUF = $dest->getElementsByTagName('UF')->item(0)->nodeValue;
         }
         $total = $dom->getElementsByTagName('total')->item(0);


### PR DESCRIPTION
Na NFCe não é obrigatório o envio do Destinatário. Somente o envio do CPF pode acontecer. Ao enviar o XML em EPEC está forçando que tenha o endereço do destinatário.